### PR TITLE
Output copy-pasteable IN TXT record line/

### DIFF
--- a/manuale/authorize.py
+++ b/manuale/authorize.py
@@ -46,7 +46,7 @@ def authorize(server, account, domains):
         logger.info("")
         for domain in domains:
             auth = authz[domain]
-            logger.info("  _acme-challenge.{}. \"{}\"".format(domain, auth['txt_record']))
+            logger.info("  _acme-challenge.{}.  IN TXT  \"{}\"".format(domain, auth['txt_record']))
         logger.info("")
         input("Press enter to continue.")
 


### PR DESCRIPTION
By adding the small "IN TXT" fragment, the _acme-challenge... text
record message becomes a valid part of zonefile and can be copied and
pasted directly into a DNS server configuration file.
