### PR TITLE
Implement OCSP Must-Staple in generated CSR

### DIFF
--- a/manuale/cli.py
+++ b/manuale/cli.py
@@ -113,7 +113,8 @@ def _issue(args):
         key_size=args.key_size,
         key_file=args.key_file,
         csr_file=args.csr_file,
-        output_path=args.output
+        output_path=args.output,
+        must_staple=args.ocsp_must_staple,
     )
 
 def _revoke(args):
@@ -196,7 +197,15 @@ def main():
     issue.add_argument('--key-file', '-k', help="Existing key file to use for the certificate")
     issue.add_argument('--csr-file', help="Existing signing request to use")
     issue.add_argument('--output', '-o', help="The output directory for created objects", default='.')
-    issue.set_defaults(func=_issue)
+    issue.add_argument('--ocsp-must-staple',
+                       dest='ocsp_must_staple',
+                       help="CSR: Request OCSP Must-Staple extension",
+                       action='store_true')
+    issue.add_argument('--no-ocsp-must-staple',
+                       dest='ocsp_must_staple',
+                       help=argparse.SUPPRESS,
+                       action='store_false')
+    issue.set_defaults(func=_issue, ocsp_must_staple=False)
 
     # Certificate revocation
     revoke = subparsers.add_parser(

--- a/manuale/issue.py
+++ b/manuale/issue.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 EXPIRATION_FORMAT = "%Y-%m-%d"
 
-def issue(server, account, domains, key_size, key_file=None, csr_file=None, output_path=None):
+def issue(server, account, domains, key_size, key_file=None, csr_file=None, output_path=None, must_staple=False):
     if not output_path or output_path == '.':
         output_path = os.getcwd()
 
@@ -57,7 +57,7 @@ def issue(server, account, domains, key_size, key_file=None, csr_file=None, outp
             logger.info("Key generated.")
             logger.info("")
 
-        csr = create_csr(certificate_key, domains)
+        csr = create_csr(certificate_key, domains, must_staple=must_staple)
 
     acme = Acme(server, account)
     try:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
 
     packages=['manuale'],
     install_requires=[
-        'cryptography >= 1.0',
+        'cryptography >= 2.1',
         'requests',
     ],
 


### PR DESCRIPTION
Support generating a CSR with extension for getting OCSP Must-Staple.
(TLS Feature 'status_request').

Raises dependency to cryptography-2.1 or newer, as that is where
TLSFeature is implemented.

(Will have a trivial conflict if PR#35 is merged first.)

Closes: https://github.com/veeti/manuale/issues/24
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>